### PR TITLE
Remove padding from platypus frame

### DIFF
--- a/complex_doc_template.py
+++ b/complex_doc_template.py
@@ -18,7 +18,11 @@ class ComplexDocTemplate(BaseDocTemplate):
     def build(self, flowables, onFirstPage=_doNothing, onEvenPages=_doNothing, onOddPages=_doNothing, canvasmaker=canvas.Canvas):
         self._calc()  # In case we changed margins sizes etc. Copied from SampleDocTemplate
 
-        frameT = Frame(self.leftMargin, self.bottomMargin, self.width, self.height, id='normal')
+        frameT = Frame(self.leftMargin, self.bottomMargin,
+                       self.width, self.height,
+                       leftPadding=0, rightPadding=0, bottomPadding=0, topPadding=0,
+                       showBoundary=0,
+                       id='normal')
 
         self.addPageTemplates([
             PageTemplate(id='First', frames=frameT, onPage=onFirstPage, pagesize=self.pagesize),


### PR DESCRIPTION
https://www.reportlab.com/snippets/15/

```python
def create_pdfdoc(pdfdoc, story):
    """
    Creates PDF doc from story.
    """
    pdf_doc = BaseDocTemplate(pdfdoc, pagesize = PAGE_SIZE,
        leftMargin = MARGIN_SIZE, rightMargin = MARGIN_SIZE,
        topMargin = MARGIN_SIZE, bottomMargin = MARGIN_SIZE)
    main_frame = Frame(MARGIN_SIZE, MARGIN_SIZE,
        PAGE_SIZE[0] - 2 * MARGIN_SIZE, PAGE_SIZE[1] - 2 * MARGIN_SIZE,
        leftPadding = 0, rightPadding = 0, bottomPadding = 0,
        topPadding = 0, id = 'main_frame')
    main_template = PageTemplate(id = 'main_template', frames = [main_frame])
    pdf_doc.addPageTemplates([main_template])

    pdf_doc.build(story)
```

~/.local/lib/python3.7/site-packages/reportlab/platypus/frames.py
```python
def __init__(self, x1, y1, width,height, leftPadding=6, bottomPadding=6,
            rightPadding=6, topPadding=6, id=None, showBoundary=0,
            overlapAttachedSpace=None,_debug=None):
```